### PR TITLE
Correzione documentazione MIPS/M68k

### DIFF
--- a/LPS/Documentazione/M68K/README.md
+++ b/LPS/Documentazione/M68K/README.md
@@ -1,5 +1,5 @@
 # Introduzione
-In m68k i registri sono formati in 3 tipi diversi:
+In m68k i registri sono formati da 3 tipi diversi:
 * `long` 32 bit
 * `word` 16 bit
 * `byte` 8 bit
@@ -102,7 +102,7 @@ Ea -> <label/$indirizzo>
 ```
 # Comandi
 
-**ATTENZIONE** In alcuni dei comandi possiamo scegliere quale parte dei registri utilizzare, se solo i primi 8 bit, i primi 16 bit o tutti e 32 bit, facciamo ciò aggiungendo uno di questi 3 dopo il comando:
+**ATTENZIONE** In alcuni dei comandi possiamo scegliere quale parte dei registri utilizzare, se solo i primi 8 bit, i primi 16 bit o tutti e 32 bit, facciamo ciò aggiungendo una di queste 3 estensioni dopo il comando:
 
 # Estensioni
 
@@ -131,7 +131,7 @@ In { } è specificata l'estensione di default
 
 ## move [l w b] {w}
 
-*move* -> Copia il contenuto del primo nel secondo. Se la destinazione è un registro indirizzi (a), di default usa formato long
+*move* -> Copia il contenuto del primo operando nel secondo. Se la destinazione è un registro indirizzi (a), di default usa formato long
 ```assembly
 move <Im/Dn/An/(An)/Ea>, <Dn/An/(An)/Ea>
 
@@ -182,7 +182,7 @@ sub d7, d0
 
 Divide il secondo registro per il primo num/reg, salva il risultato nel secondo registro. Il primo operando viene letto con formato `word`, il secondo con formato `long`. 
 
-**ATTENZIONE** salva il risultato della divisone nei primi 16 bit del secondo registro, il resto negli ultimi 16 bit. Se si vuole accedere al resto, usare il comando [swap](#swap)
+**ATTENZIONE** salva il quoziente della divisone nei primi 16 bit del secondo registro, il resto negli ultimi 16 bit. Se si vuole accedere al resto, usare il comando [swap](#swap)
 ```assembly
 divs <Im/Dn/(An)/Ea>, <Dn>
 divu <Im/Dn/(An)/Ea>, <Dn>
@@ -198,7 +198,7 @@ al termine dell'esecuzione del codice il registro `d0` sarà composto dai seguen
 
 dove `0001` è il resto, mentre `0009` è il risultato
 
-per ottenere il risultato serve copiare il registro in formato word, copiando solo i **primi 16 bit** di esso
+per ottenere il quoziente serve copiare il registro in formato word, copiandone solo i **primi 16 bit**
 
 per ottenere il resto serve eseguire `swap` sul registro, e poi ripetere quanto detto sopra:
 ```assembly
@@ -301,13 +301,13 @@ ext.w d2
 ```
 
 # Comandi branch e comparazione
-Questi comandi vengono usati per mettere a confronto un registro ad un altro registro, o ad un numero immediato, per poi andare nella label se la condizione è vera.
+Questi comandi vengono usati per mettere a confronto un registro con un altro registro, o con un numero immediato, per poi andare nella label se la condizione è vera.
 
-In m68k la comparazione e branch vengono effettuati in comandi separati. Il primo ,`cmp`, mette a confronto due valori, poi con i vari comandi di branch, si decide a quale label andare. 
+In m68k, comparazione e branch vengono effettuati in comandi separati. Il primo ,`cmp`, mette a confronto due valori, poi con i vari comandi di branch, si decide a quale label andare. 
 
 Ci sono due comandi di comparazione, quello rispetto due valori `cmp`, e quello rispetto allo zero `tst`. Questi comandi accettano l'utilizzo di `.l` `.w` `.b`
 
-Entrambi i comandi `cmp` e `tst` salvano il risultato del confronto nel `CCR`, che poi verranno utilizzati nei comandi di branch scritti sotto.
+Entrambi i comandi `cmp` e `tst` salvano il risultato del confronto nel `CCR`, che poi verrà utilizzato nei comandi di branch scritti sotto.
 
 ## tst [l w b] {w}
 *test* -> Comparazione con lo 0
@@ -360,14 +360,14 @@ bls                 |      b <= a         | *Branch lower than or same*
 bhi                 |      b > a          | *Branch higher than*
 bhs                 |      b >= a         | *Branch than or same* 
 ## Comandi di branch speciali (CCR)
-In oltre ci sono altri comandi di branch "speciali", molti comandi in m68k, una volta eseguiti, comparano il registro destinazione con lo 0, in oltre tengono conto anche del segno del numero, se c'è stato un overflow, etc... Queste informazioni vengono salvate nel CCR, ed oltre ai comandi di branch precedenti, come i precedenti comandi di branch, hanno sintassi: 
+Esistono dei comandi di branch "speciali": molti comandi in m68k, una volta eseguiti, comparano il registro destinazione con lo 0, inoltre tengono conto anche del segno del numero, se c'è stato un overflow, etc... Queste informazioni vengono salvate nel CCR. Come i precedenti comandi di branch, hanno sintassi: 
 ```assembly
 comando <label>
 ```
 e sono:
 * `bmi` se un valore è negativo
 * `bpl` se un valore è positivo
-* `bcs` (Branch Carry Set) se dopo aver fatto un operazione aritmetica su numeri unsigned, se c'è stato riporto nella cifra più a sinistra (più significativa), per esempio, prendendo un byte per numero, si fa `255 + 9`, il risultato sarà `8`, perchè `264` è più grande del numero massimo rappresentabile da un byte, che è 255, se ciò è accaduto, allora si dice che c'è stato **riporto**. vale anche se un numero va da positivo a negativo, es: 1-3 sarà 254. 
+* `bcs` (Branch Carry Set) se dopo aver fatto un'operazione aritmetica su numeri unsigned, c'è stato riporto nella cifra più a sinistra (più significativa), per esempio, prendendo un byte per numero, si fa `255 + 9`, il risultato sarà `8`, perchè `264` è più grande del numero massimo rappresentabile da un byte, che è 255, se ciò è accaduto, allora si dice che c'è stato **riporto**. Vale anche se un numero va da positivo a negativo, es: 1-3 sarà 254. 
 * `bcc` (Branch Carry Clear) come `bcs`, ma se **NON** c'è stato riporto
 * `bvs` (Branch oVerflow Set) se dopo aver fatto una operazione aritmetica, viene causato un overflow (per esempio: se venissero sommati 2 numeri positivi signed, e ne uscisse come risultato un numero negativo, è Overflow)
 * `bvc` (Branch oVerflow Clear) come `bvs`, ma **NON** c'è stato Overflow
@@ -380,7 +380,7 @@ bra <label>
 jmp <label>
 ```
 ## Lettura degli elementi del CCR
-Come visto prima nei branch, nel CCR troviamo varie informazioni durante l'esecuzione del codice, come per esempio se c'è stato un overflow, se un numero è maggiore, se è minore, etc... Possiamo leggere queste informazioni tramite questi comandi, se una condizione è vera, allora tutti i bit saranno settati a 1, sennò saranno settati a 0. hanno tutti sintassi:
+Come visto prima nei branch, nel CCR troviamo varie informazioni durante l'esecuzione del codice, come per esempio se c'è stato un overflow, se un numero è maggiore, se è minore, etc... Possiamo leggere queste informazioni tramite questi comandi, se una condizione è vera, allora tutti i bit saranno settati a 1, altrimenti saranno settati a 0. Hanno tutti sintassi:
 ```assembly
 comando <destinazione>
 ```
@@ -406,7 +406,7 @@ comando <destinazione>
 Le operazioni sui bit ci permettono di effettuare modifiche ai singoli bit di un registro, come spostarli a sinistra/destra, invertirli, etc...
 
 ## not, or, and, eor
-Effettua le operazioni not, or, and, xor, tra un registro e una maschera. La maschera è una sequenza di bit che specificano a quali posizioni si deve effettuare l'operazione logica. I vari operatori hanno funzioni equiparabili a:
+Effettua le operazioni not, or, and, xor, tra un registro e una maschera. La maschera è una sequenza di bit che specificano su quali posizioni si deve effettuare l'operazione logica. I vari operatori hanno funzioni equiparabili a:
 * `NOT` Inverso di tutti i bit (1 diventa 0, 0 diventa 1), non usa una maschera
 * `OR`  Setta ad 1 i bit alle posizioni della maschera, senza modificare gli altri
 * `AND` Prelevare i bit alle posizioni della maschera, oppure controllare se un bit è segnato ad 1 nella posizione segnata nella maschera
@@ -498,7 +498,7 @@ lsr.l #5, d0
     ;d0 = 043B2843 (stavolta con .l l'intero valore è stato shiftato)
 ```
 
-Lo `shift destro` logico è uguale a calcolare `N/2^k` dove N è il numero dove effettuare lo shift e `k` è la quantità dello shift, oppure semplicemente, ogni volta che spostiamo di una posizione, il numero viene diviso per 2.
+Lo `shift destro` logico equivale a calcolare `N/2^k` dove N è il numero dove effettuare lo shift e `k` è la quantità dello shift, oppure semplicemente, ogni volta che spostiamo di una posizione, il numero viene diviso per 2.
 
 
 ## asr / asl [l w b] {w}
@@ -526,12 +526,12 @@ asr.l #5, d0
     ;d0 = FC3B2FC3 (stavolta con .l l'intero valore è stato shiftato)
 ```
 
-Aritmeticamente, lo  `shift sinistro` aritmetico è uguale a calcolare `N*2^k` dove N è il numero dove effettuare lo shift e `k` è la quantità dello shift, oppure semplicemente, ogni volta che spostiamo di una posizione, il numero viene moltiplicato per 2. 
+Aritmeticamente, lo  `shift sinistro` aritmetico è uguale a calcolare `N*2^k`, dove N è il numero dove effettuare lo shift e `k` è la quantità dello shift, oppure semplicemente, ogni volta che spostiamo di una posizione, il numero viene moltiplicato per 2. 
 
-Mentre per lo `shift destro` aritmetico è uguale a calcolare `N/2^k` dove N è il numero dove effettuare lo shift e `k` è la quantità dello shift, oppure semplicemente, ogni volta che spostiamo di una posizione, il numero viene diviso per 2.
+Mentre per lo `shift destro` aritmetico è uguale a calcolare `N/2^k`, dove N è il numero dove effettuare lo shift e `k` è la quantità dello shift, oppure semplicemente, ogni volta che spostiamo di una posizione, il numero viene diviso per 2.
 
 
-Bisogna fare attenzione nel caso che il numero sia negativo, o se il numero è grande, visto che potrebbe andare in overflow.
+Bisogna fare attenzione nel caso in cui il numero sia negativo, o se il numero è grande, visto che potrebbe verificarsi un overflow.
 
 ## rol / ror [l w b] {w}
 *rotate left / rotate right* -> Prendendo per esempio la rotazione a destra, il comando sposterà a destra di un tot numero di bit, e li posizionerà a sinistra (al posto dei bit da aggiungere). Lo stesso vale per rol, ma verso sinistra
@@ -556,9 +556,9 @@ rol.l #5, d0
 # Operazioni sui singoli bit
 Servono per effettuare operazioni sui singoli bit. Tutti i comandi seguenti, prima di modificare un bit, settano il CCR `equal` al valore del bit da cambiare, e poi modificano il bit. Se il secondo operando è un registro viene letto tutto il registro, se non lo è, vengono letti solo i primi 8 bit.
 
-Il primo operando è il bit da leggere, il secondo sarà dove effettuare l'operazione e salvarla. 
+Il primo operando è il bit da leggere, il secondo sarà dove effettuare e salvare l'operazione. 
 ## btst
-*Bit test* -> Testa il bit a posizione specificata del registro, setta la condizione del CCR `equal` al valore del bit a quella posizione, poi possiamo usare il comando `beq` per i branch. Non modifica la destinazione
+*Bit test* -> Testa il bit a posizione specificata del registro, setta la condizione del CCR `equal` al valore del bit a quella posizione, poi possiamo usare il comando `beq` per il branch. Non modifica la destinazione
 
 ```assembly
 btst <Im/Dn/(An)/Ea>, <Dn/(An)/Ea>
@@ -582,13 +582,13 @@ bset <Im/Dn/(An)/Ea>, <Dn/(An)/Ea>
 ```
 
 # La memoria in M68K
-La memoria in M68K può essere vista come una lista di byte, dove ogni byte nella lista ha una posizione chiamata "address". La gestione dei dati salvati all'interno della memoria è completamente lasciata allo sviluppatore che scrive il programma, quindi dovranno essere tenuti in conto la lunghezza in byte dei vari formati di dati che andremo a salvare. 
+La memoria in M68K può essere vista come una lista di byte, dove ogni byte nella lista ha una posizione chiamata "address". La gestione dei dati salvati all'interno della memoria è completamente lasciata allo sviluppatore che scrive il programma, quindi andrà tenuti in considerazione la lunghezza in byte dei vari formati di dato che andremo a salvare. 
 
 
 **ATTENZIONE**, quando andiamo a leggere e scrivere negli address, in base alla grandezza del formato che vogliamo usare, l'indirizzo scelto dovrà essere un multiplo del formato scelto. Per esempio, non possiamo salvare una word (4 byte) all'indirizzo 2021, perchè non è modulo di 4, ma possiamo salvarlo in 2024
 
 ## Formati di dato e allineamento
-Ogni formato di dato ha la propria lunghezza, dovremmo tenerne conto quando salviamo e leggiamo dalla memoria. I dati letti/scritti verranno letti dall'indirizzo specificato, fino all'`indirizzo + lunghezza`.
+Ogni formato di dato ha la propria lunghezza, dovremo tenerne conto quando salviamo e leggiamo dalla memoria. I dati letti/scritti verranno letti dall'indirizzo specificato, fino all'`indirizzo + lunghezza`.
 
 Alcuni formati standard, diversi dal formato **byte**, definiscono una restrizione agli indirizzi validi per le 
 parole standard di tale formato, chiamata `vincolo di allineamento`.
@@ -597,27 +597,27 @@ parole standard di tale formato, chiamata `vincolo di allineamento`.
 * `word` : ha lunghezza 16 bit (2 parole), fattore di allineamento 2
 * `long` : ha lunghezza 32 bit (4 parole), fattore di allineamento 2
 
-Ad esempio, per salvare una **word** all'address 0x2000, il dato verrà salvato agli indirizzi 0x2000 e 0x2001 e, dunque, la successiva **word** o **long**, non potrà essere salvata a partire dall'address 0x2001 ma bensì dovrà essere salvata a partire dall'address 0x2002.
+Ad esempio, per salvare una **word** all'address $2000, il dato verrà salvato agli indirizzi $2000 e $2001 e, dunque, la successiva **word** o **long**, non potrà essere salvata a partire dall'address $2001, bensì dovrà essere salvata a partire dall'address $2002.
 
-Importante è sapere il modo in cui la memoria viene letta/scritta. Esistono due tipologie chiamate `little endian` e `big endian`. 
+Importante è sapere il modo in cui i dati in memoria vengono letti/scritti. Esistono due tipologie chiamate `little endian` e `big endian`. 
 
 In m68k, per la lettura/scrittura in memoria viene usato il [Big endian](#Big-endian).
 
 ### Little endian
-Little endian è quando i byte sono salvati da destra verso sinistra, partendo dal più significativo. Per esempio il numero `0x1234` viene salvato in memoria come `0x34 0x12`.
+Little endian è quando i byte sono salvati da destra verso sinistra, partendo dal più significativo. Per esempio il numero esadecimale `#$1234` viene salvato in memoria come `#$34 #$12`.
 
 ### Big endian
-Big endian è quando i byte sono salvati da sinistra verso destra, partendo dal più significativo. Per esempio il numero `0x1234` viene salvato in memoria come `0x12 0x34`.
+Big endian è quando i byte sono salvati da sinistra verso destra, partendo dal più significativo. Per esempio il numero esadecimale `#$1234` viene salvato in memoria come `#$12 #$34`.
 
 ## Utilizzo della memoria
-Per utilizzare la memoria all'interno del programma, ci basterà specificare il numero dell'indirizzo della memoria come operando, scrivendolo in maniera `$numero_indirizzo`, esempio `$2000`. Alternativamente, possiamo creare una `variabile` alias all'inizio del programma che indica a quale indirizzo fa riferimento l' alias. Facciamo ciò tramite il comando [equ](#equ)
+Per utilizzare la memoria all'interno del programma, ci basterà specificare il numero dell'indirizzo della memoria come operando, scrivendolo in maniera `$numero_indirizzo`, esempio `$2000`. Alternativamente, possiamo creare una `variabile` alias all'inizio del programma che indica a quale indirizzo fa riferimento l'alias. Facciamo ciò tramite il comando [equ](#equ)
 
 ```assembly
 unaVariabile equ $3000
 
 move.w #1234, $00002000
-    ; la word 1234 viene salvata in memoria all'indirizzo 0x2000
-    ; quindi viene salvato 12 all'indirizzo 0x2000 e 34 all'indirizzo 0x2001
+    ; la word 1234 viene salvata in memoria all'indirizzo $2000
+    ; quindi viene salvato 12 all'indirizzo $2000 e 34 all'indirizzo $2001
 move.w #1234, unaVariabile
 ```
 Naturalmente la lettura e scrittura dipendono dal formato di dato utilizzato.
@@ -631,7 +631,7 @@ Deve essere messo prima di `ORG $2000` e senza indentazione. Verrà convertito d
 <nome_variabile>:  equ  <adr/Im> 
 
 unaVariabile: equ 5020
-unaVariabile: equ $0xFF0022
+unaVariabile: equ #$FF0022
 
 ```
 Esempio:
@@ -645,7 +645,7 @@ unaVariabile: equ 5020
 
 # Indirizzi di Memoria e Label
 Gli indirizzi possono essere scritti in forme più comode utilizzando `label`. 
-Ogni label è legata ad un indirizzo di memoria, ovvero rappresenta tale indirizzo. In fase di traduzione l'assembler trasforma ogni label nell'indirizzo ad essa legato. Ha quindi senso operazioni come
+Ogni label è legata ad un indirizzo di memoria, ovvero rappresenta tale indirizzo. In fase di traduzione l'assembler trasforma ogni label nell'indirizzo ad essa legato. Hanno quindi senso operazioni come
 ```assembly
 ; se pippo è una label, l'indirizzo successivo sarà l'indirizzo pippo+1, quello dopo ancora pippo+2, e così via..-
 
@@ -705,7 +705,7 @@ Per esempio per definire un array di 5 elementi tutti a valore 1:
     org $4000
 unArray: dc.l 1,1,1,1,1
 ```
-Potremmo poi accedere ai valori dell'array usando il nome della label. Se vogliamo iterare gli elementi dell'array, dovremmo leggere l'indirizzo dell'array, e poi incrementarlo in base alla grandezza degli elementi. Oppure se dobbiamo leggere un elemento specifico, possiamo usare `label+posizione`
+Potremo poi accedere ai valori dell'array usando il nome della label. Se volessimo iterare gli elementi dell'array, dovremo leggere l'indirizzo dell'array, e poi incrementarlo in base alla grandezza degli elementi. Oppure se dobbiamo leggere un elemento specifico, possiamo usare `label+posizione`
 ```assembly
 ; STATICO
     ; copia elemento a posizione 3

--- a/LPS/Documentazione/M68K/README.md
+++ b/LPS/Documentazione/M68K/README.md
@@ -582,7 +582,7 @@ bset <Im/Dn/(An)/Ea>, <Dn/(An)/Ea>
 ```
 
 # La memoria in M68K
-La memoria in M68K può essere vista come una lista di byte, dove ogni byte nella lista ha una posizione chiamata "address". La gestione dei dati salvati all'interno della memoria è completamente lasciata allo sviluppatore che scrive il programma, quindi andrà tenuti in considerazione la lunghezza in byte dei vari formati di dato che andremo a salvare. 
+La memoria in M68K può essere vista come una lista di byte, dove ogni byte nella lista ha una posizione chiamata "address". La gestione dei dati salvati all'interno della memoria è completamente lasciata allo sviluppatore che scrive il programma, quindi andrà tenuta in considerazione la lunghezza in byte dei vari formati di dato che andremo a salvare. 
 
 
 **ATTENZIONE**, quando andiamo a leggere e scrivere negli address, in base alla grandezza del formato che vogliamo usare, l'indirizzo scelto dovrà essere un multiplo del formato scelto. Per esempio, non possiamo salvare una word (4 byte) all'indirizzo 2021, perchè non è modulo di 4, ma possiamo salvarlo in 2024

--- a/LPS/Documentazione/MIPS/README.md
+++ b/LPS/Documentazione/MIPS/README.md
@@ -282,7 +282,7 @@ mtlo 50
 ```
 
 # Comandi branch e comparazione
-Questi comandi vengono usati per mettere a confronto un registro ad un altro registro, o ad un numero immediato, per poi andare nella label se la condizione è vera.
+Questi comandi vengono usati per mettere a confronto un registro con un altro, o ad un numero immediato, per poi andare nella label se la condizione è vera.
 
 ## Branch incondizionato
 Utilizzato molto nei loop, il branch incondizionato esegue il salto alla label ogni volta.
@@ -452,10 +452,10 @@ rol $s0, $s0, 2
 
 # Input e output (syscall)
 Le syscall ci permettono di comunicare con le api del sistema operativo. Un esempio sono quelle di lettura e scrittura del terminale.
-Il funzionamento generare è quello di inserire il tipo di comando che vogliamo effettuare nel registro `$v0`, ed eseguire la `syscall`.
+Il funzionamento generale è quello di inserire il tipo di comando che vogliamo effettuare nel registro `$v0`, ed eseguire la `syscall`.
 
 ## Input numero intero
-Per effettuare l'input un numero intero (leggere da terminale) si deve settare il registro `$v0` a `5`, effettuare la syscall, e poi leggere il risultato in `$v0`
+Per effettuare l'input di un numero intero (leggere da terminale), si deve settare il registro `$v0` a `5`, effettuare la syscall, e poi leggere il risultato in `$v0`
 
 ```assembly
 li $v0, 5
@@ -464,7 +464,7 @@ move $s1, $v0
 ```
 
 ## Output numero intero
-Per effettuare l'output di un numero intero, si setta il registro di `$v0` a `1`, e il numeri da stampare all'interno del registro `$a0`
+Per effettuare l'output di un numero intero, si setta il registro di `$v0` a `1`, e il numero da stampare all'interno del registro `$a0`
 
 ```assembly
 li $a0, 20
@@ -473,12 +473,12 @@ syscall
     ;stampa 20
 ```
 # La memoria in MIPS
-La memoria in MIPS può essere vista come una lista di byte, dove ogni byte nella lista ha una posizione chiamata "address". La gestione dei dati salvati all'interno della memoria è completamente lasciata allo sviluppatore che scrive il programma, quindi dovranno essere tenuti in conto la lunghezza in byte dei vari formati di dati che andremo a salvare. 
+La memoria in MIPS può essere vista come una lista di byte, dove ogni byte nella lista ha una posizione chiamata "address". La gestione dei dati salvati all'interno della memoria è completamente lasciata allo sviluppatore che scrive il programma, quindi dovrà essere tenuta in considerazione la lunghezza in byte dei vari formati di dato che andremo a salvare. 
 
 **ATTENZIONE**, quando andiamo a leggere e scrivere negli address, in base alla grandezza del formato che vogliamo usare, l'indirizzo scelto dovrà essere un multiplo del formato scelto. Per esempio, non possiamo salvare una word (4 byte) all'indirizzo 2021, perchè non è modulo di 4, ma possiamo salvarlo in 2024
 
 ## Formati di dato
-Ogni formato di dato ha la propria lunghezza, dovremmo tenerne conto quando salviamo e leggiamo dalla memoria. I dati letti/scritti verranno letti dall'indirizzo specificato, fino all'`indirizzo + lunghezza`.
+Ogni formato di dato ha la propria lunghezza, dovremo tenerne conto quando salviamo e leggiamo dalla memoria. I dati letti/scritti verranno letti dall'indirizzo specificato, fino all'`indirizzo + lunghezza`.
 
 Alcuni formati standard, diversi dal formato **byte**, definiscono una restrizione agli indirizzi validi per le 
 parole standard di tale formato, chiamata `vincolo di allineamento`.
@@ -486,13 +486,13 @@ parole standard di tale formato, chiamata `vincolo di allineamento`.
 * `word` : ha lunghezza 16 bit (2 parole), fattore di allineamento 2
 * `long` : ha lunghezza 32 bit (4 parole), fattore di allineamento 4
 
-Ad esempio, per salvare una **word** all'address 0x2000, il dato verrà salvato agli indirizzi 0x2000 e 0x2001 e, dunque, la successiva **word**, non potrà essere salvata a partire dall'address 0x2001 ma bensì dovrà essere salvata a partire dall'address 0x2002.
+Ad esempio, per salvare una **word** all'address 0x2000, il dato verrà salvato negli indirizzi 0x2000 e 0x2001 e, dunque, la successiva **word**, non potrà essere salvata a partire dall'address 0x2001, bensì dovrà essere salvata a partire dall'address 0x2002.
 
-Importante è sapere il modo in cui la memoria viene letta/scritta. 
+Importante è sapere il modo in cui i dati in memoria vengono letti/scritti. 
 
 Esistono due tipologie chiamate `little endian` e `big endian`. 
 
-In MIPS, per la lettura/scrittura im memoria può essere usato sia il [Big endian](#Big-endian) che il [Little endian](#little-endian).
+In MIPS, per la lettura/scrittura in memoria può essere usato sia il [Big endian](#Big-endian) che il [Little endian](#little-endian).
 
 MIPS32-MARS utilizza il [Little endian](#little-endian).
 
@@ -503,10 +503,10 @@ Little endian è quando i byte sono salvati da destra verso sinistra, partendo d
 Big endian è quando i byte sono salvati da sinistra verso destra, partendo dal più significativo. Per esempio il numero `0x1234` viene salvato in memoria come `0x12 0x34`.
 
 ## Utilizzo della memoria
-Per utilizzare la memoria all'interno del programma, ci basterà specificare il numero dell'indirizzo della memoria come operando, scrivendolo in maniera `$numero_indirizzo`, esempio `$2000`. Alternativamente, possiamo creare una `variabile` alias all'inizio del programma che indica a quale indirizzo fa riferimento l' alias. Facciamo ciò tramite il comando [.eqv](#.eqv)
+Per utilizzare la memoria all'interno del programma, ci basterà specificare il numero dell'indirizzo della memoria come operando, scrivendolo in maniera `$numero_indirizzo`, esempio `$2000`. Alternativamente, possiamo creare una `variabile` alias all'inizio del programma che indica a quale indirizzo fa riferimento l'alias. Facciamo ciò tramite il comando [.eqv](#.eqv)
 
 
-Su MIPS la memoria viene gestita principalmente dai comandi [lw-lh-lb](#Trasferimento-da-registro-a-memoria) e [sw-sh-sb](#Trasferimento-da-memoria-a-registro), rispettivamente per salvare in e caricare dalla memoria;
+In MIPS la memoria viene gestita principalmente dai comandi [lw-lh-lb](#Trasferimento-da-registro-a-memoria) e [sw-sh-sb](#Trasferimento-da-memoria-a-registro), rispettivamente per salvare in e caricare dalla memoria;
 
 ## .eqv
 *equal variable* -> Crea un alias dell'indirizzo della memoria. 
@@ -599,7 +599,7 @@ la $s0, unaLabel
 
 # Indirizzi di Memoria e Label
 Gli indirizzi possono essere scritti in forme più comode utilizzando `label`. 
-Ogni label è legata ad un indirizzo di memoria, ovvero rappresenta tale indirizzo. In fase di traduzione l'assembler trasforma ogni label nell'indirizzo ad essa legato. Ha quindi senso operazioni come
+Ogni label è legata ad un indirizzo di memoria, ovvero rappresenta tale indirizzo. In fase di traduzione l'assembler trasforma ogni label nell'indirizzo ad essa legato. Hanno quindi senso operazioni come
 
 ```assembly
 ; se pippo è una label, l'indirizzo successivo sarà l'indirizzo pippo+1, quello dopo ancora pippo+2, e così via...
@@ -665,7 +665,7 @@ Per esempio per definire un array di 5 elementi tutti a valore 1:
     .data   $10010000
 unArray:    .byte   1,1,1,1,1
 ```
-Potremmo poi accedere ai valori dell'array usando il nome della label. Se vogliamo iterare gli elementi dell'array, dovremmo leggere l'indirizzo dell'array, e poi incrementarlo in base alla grandezza degli elementi. Oppure se dobbiamo leggere un elemento specifico, possiamo usare `label+posizione`
+Potremo poi accedere ai valori dell'array usando il nome della label. Se volessimo iterare gli elementi dell'array, dovremo leggere l'indirizzo dell'array, e poi incrementarlo in base alla grandezza degli elementi. Oppure se dobbiamo leggere un elemento specifico, possiamo usare `label+posizione`
 ```assembly
 ; STATICO
     .data   $10010000


### PR DESCRIPTION
Correzione di alcuni errori di battitura nelle documentazioni MIPS/M68k 
Sostituiti alcuni termini con altri più appropriati per migliorare la leggibilità complessiva 
Nella documentazione M68k sostituiti alcuni indirizzi/numeri esadecimali che venivano rappresentati come in MIPS (0x...). 

Discord: markooo384#5640